### PR TITLE
fix: Trims atomic class list string before parsing

### DIFF
--- a/__tests__/createAtomicHelper.spec.js
+++ b/__tests__/createAtomicHelper.spec.js
@@ -7,9 +7,16 @@ describe('The atomic function', () => {
     beforeEach(() => {
         StyleSheetTestUtils.suppressStyleInjection();
     });
+    const atomicStyles = StyleSheet.create(atomicObj);
+    const atomic = createAtomicHelper({ atomicStyles, css });
+    describe('when there are spaces at the beginning/end of the atomic classes string', () => {
+        it('should not throw warnings', () => {
+            const warn = jest.spyOn(global.console, 'warn');
+            atomic('  absolute  ');
+            expect(warn).not.toHaveBeenCalled();
+        });
+    });
     it('should execute the aphrodite css function on every argument', () => {
-        const atomicStyles = StyleSheet.create(atomicObj);
-        const atomic = createAtomicHelper({ atomicStyles, css });
         const aphroditeSuffix = '_\\S+';
         const aphroditeClassList = new RegExp(
             `absolute${aphroditeSuffix} db${aphroditeSuffix}`

--- a/src/utils/createAtomicHelper.js
+++ b/src/utils/createAtomicHelper.js
@@ -3,6 +3,7 @@ import { default as joinClasses } from './joinClasses';
 export default ({ atomicStyles, css }) => atomicClasses => {
     const whitespace = /\s+/g;
     const atomicClassesArray = atomicClasses
+        .trim()
         .split(whitespace)
         .map(className => {
             if (!atomicStyles[className]) {


### PR DESCRIPTION
- Ensures that passing an atomic class list string with spaces at the beginning or end does not throw warnings about invalid classes.